### PR TITLE
fix to cre-type parser in synapse_comparison.py

### DIFF
--- a/synapse_comparison.py
+++ b/synapse_comparison.py
@@ -154,7 +154,7 @@ def summary_plot(grand_mean, avg_est, grand_est, i, plot=None, color=None, name=
 if args.cre_type is not None:
     cre_types = args.cre_type.split(',')
     if args.calcium is True and len(cre_types) == 1:
-        cre_type = cre_types.split('-')
+        cre_type = cre_types[0].split('-')
         expts = all_expts.select(cre_type=cre_type, calcium='high', start=args.start)
         legend = ("%s->%s, calcium = 2.0mM " % (cre_type[0], cre_type[1]))
         dist_plots = expts.distance_plot(cre_type[0], cre_type[1], color=(0, 10), name=legend)
@@ -173,7 +173,7 @@ if args.cre_type is not None:
         print('p = %f (KS test)' % ks.pvalue)
         #amp_plots[0].addLegend('p = %f (KS test)' % ks.pvalue)
     elif args.age is not None and len(args.age.split(',')) >= 2 and len(cre_types) == 1:
-        cre_type = cre_types.split('-')
+        cre_type = cre_types[0].split('-')
         ages = args.age.split(',')
         expts = all_expts.select(age=ages[0], start=args.start)
         legend = ("%s->%s, age = P%s " % (cre_type[0], cre_type[1], ages[0]))


### PR DESCRIPTION
Thought I had caught this but guess not. Need to fix parsing for cre-types when only 1 is specified